### PR TITLE
feat: Template, Icon 관련 로직 리팩토링

### DIFF
--- a/src/main/java/com/linku/backend/domain/common/template/IconSnapshot.java
+++ b/src/main/java/com/linku/backend/domain/common/template/IconSnapshot.java
@@ -1,12 +1,15 @@
 package com.linku.backend.domain.common.template;
 
 import jakarta.persistence.Embeddable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter @Setter
+@Getter
 @Builder
 public class IconSnapshot {
     private String iconUrl;

--- a/src/main/java/com/linku/backend/domain/common/template/TemplateItemPosition.java
+++ b/src/main/java/com/linku/backend/domain/common/template/TemplateItemPosition.java
@@ -1,12 +1,15 @@
 package com.linku.backend.domain.common.template;
 
 import jakarta.persistence.Embeddable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter @Setter
+@Getter
 @Builder
 public class TemplateItemPosition {
     private Integer x;

--- a/src/main/java/com/linku/backend/domain/common/template/TemplateItemSize.java
+++ b/src/main/java/com/linku/backend/domain/common/template/TemplateItemSize.java
@@ -1,12 +1,15 @@
 package com.linku.backend.domain.common.template;
 
 import jakarta.persistence.Embeddable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter @Setter
+@Getter
 @Builder
 public class TemplateItemSize {
     private Integer width;

--- a/src/main/java/com/linku/backend/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/com/linku/backend/domain/template/repository/TemplateRepository.java
@@ -13,7 +13,14 @@ import java.util.Optional;
 @Repository
 public interface TemplateRepository extends JpaRepository<Template, Long> {
 
-    Optional<Template> findByTemplateIdAndOwner_UserIdAndStatus(Long templateId, Long userId, Status status);
+    @Query("SELECT DISTINCT t FROM Template t LEFT JOIN FETCH t.items " +
+            "WHERE t.templateId = :templateId " +
+            "AND t.owner.userId = :userId " +
+            "AND t.status = :status")
+    Optional<Template> findTemplateWithItemsByIdAndOwnerIdAndStatus(
+            @Param("templateId") Long templateId,
+            @Param("userId") Long userId,
+            @Param("status") Status status);
 
     @Query("SELECT t FROM Template t WHERE t.owner.userId = :userId AND t.cloned = false AND t.status = :status ORDER BY " +
             "CASE WHEN :sort = 'newest' THEN t.createdAt END DESC, " +

--- a/src/main/java/com/linku/backend/domain/template/service/TemplateService.java
+++ b/src/main/java/com/linku/backend/domain/template/service/TemplateService.java
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -94,10 +94,7 @@ public class TemplateService {
         templateValidator.validateTemplateItemsForUpdate(request.getHeight(), request.getItems());
 
         updateTemplateBasicInfo(template, request);
-        updateTemplateItems(template, request);
-        
-        List<TemplateItem> activeItems = templateItemRepository.findAllByTemplate_TemplateIdAndStatus(templateId, Status.ACTIVE);
-        template.setItems(activeItems);
+        updateTemplateItems(template, request.getItems());
 
         return convertToTemplateResponse(template);
     }
@@ -185,64 +182,40 @@ public class TemplateService {
         template.setHeight(request.getHeight());
     }
 
-    private void updateTemplateItems(Template template, TemplateUpdateRequest request) {
-        List<TemplateItem> existingItems = templateItemRepository.findAllByTemplate_TemplateIdAndStatus(
-                template.getTemplateId(), Status.ACTIVE);
+    private void updateTemplateItems(Template template, List<TemplateItemUpdateRequest> requestItems) {
+        Map<Long, TemplateItemUpdateRequest> itemRequestsMap = requestItems.stream()
+                .filter(item -> item.getTemplateItemId() != null)
+                .collect(Collectors.toMap(TemplateItemUpdateRequest::getTemplateItemId, item -> item));
 
-        List<Long> requestIds = request.getItems().stream()
-                .map(TemplateItemUpdateRequest::getTemplateItemId)
-                .filter(Objects::nonNull)
-                .toList();
+        template.getItems().removeIf(item -> !itemRequestsMap.containsKey(item.getTemplateItemId()));
 
-        List<TemplateItem> itemsToDelete = existingItems.stream()
-                .filter(item -> !requestIds.contains(item.getTemplateItemId()))
-                .collect(Collectors.toList());
-        
-        templateItemRepository.deleteAll(itemsToDelete);
+        template.getItems().forEach(item -> {
+            TemplateItemUpdateRequest request = itemRequestsMap.get(item.getTemplateItemId());
+            item.setName(request.getName());
+            item.setSiteUrl(request.getSiteUrl());
+            item.setPosition(templateItemPositionRequestMapper.toEntity(request.getPosition()));
+            item.setSize(templateItemSizeRequestMapper.toEntity(request.getSize()));
+            item.setIcon(templateItemIconRequestMapper.toEntity(request.getIcon()));
+        });
 
-        for (TemplateItemUpdateRequest itemReq : request.getItems()) {
-            if (itemReq.getTemplateItemId() != null) {
-                updateExistingTemplateItem(existingItems, itemReq);
-            } else {
-                TemplateItem newItem = createNewTemplateItem(template, itemReq);
-                template.getItems().add(newItem);
-            }
-        }
-    }
-
-    private void updateExistingTemplateItem(List<TemplateItem> existingItems, TemplateItemUpdateRequest itemReq) {
-        TemplateItem item = existingItems.stream()
-                .filter(e -> e.getTemplateItemId().equals(itemReq.getTemplateItemId()))
-                .findFirst()
-                .orElseThrow(() -> LinkuException.of(ResponseCode.TEMPLATE_ITEM_NOT_FOUND));
-
-        item.setName(itemReq.getName());
-        item.setSiteUrl(itemReq.getSiteUrl());
-        item.setPosition(templateItemPositionRequestMapper.toEntity(itemReq.getPosition()));
-        item.setSize(templateItemSizeRequestMapper.toEntity(itemReq.getSize()));
-        item.setIcon(templateItemIconRequestMapper.toEntity(itemReq.getIcon()));
-        item.setStatus(Status.ACTIVE);
-    }
-
-    private TemplateItem createNewTemplateItem(Template template, TemplateItemUpdateRequest itemReq) {
-        return TemplateItem.builder()
-                .template(template)
-                .name(itemReq.getName())
-                .siteUrl(itemReq.getSiteUrl())
-                .position(templateItemPositionRequestMapper.toEntity(itemReq.getPosition()))
-                .size(templateItemSizeRequestMapper.toEntity(itemReq.getSize()))
-                .icon(templateItemIconRequestMapper.toEntity(itemReq.getIcon()))
-                .status(Status.ACTIVE)
-                .build();
+        requestItems.stream()
+                .filter(item -> item.getTemplateItemId() == null)
+                .forEach(itemReq -> template.getItems().add(TemplateItem.builder()
+                        .template(template)
+                        .name(itemReq.getName())
+                        .siteUrl(itemReq.getSiteUrl())
+                        .position(templateItemPositionRequestMapper.toEntity(itemReq.getPosition()))
+                        .size(templateItemSizeRequestMapper.toEntity(itemReq.getSize()))
+                        .icon(templateItemIconRequestMapper.toEntity(itemReq.getIcon()))
+                        .status(Status.ACTIVE)
+                        .build()));
     }
 
     private void softDeleteTemplate(Template template) {
         template.setStatus(Status.DELETED);
         template.setDeletedAt(LocalDateTime.now());
 
-        List<TemplateItem> items = templateItemRepository.findAllByTemplate_TemplateIdAndStatus(
-                template.getTemplateId(), Status.ACTIVE);
-        items.forEach(item -> {
+        template.getItems().forEach(item -> {
             item.setStatus(Status.DELETED);
             item.setDeletedAt(LocalDateTime.now());
         });

--- a/src/main/java/com/linku/backend/domain/template/service/TemplateService.java
+++ b/src/main/java/com/linku/backend/domain/template/service/TemplateService.java
@@ -149,7 +149,7 @@ public class TemplateService {
     }
 
     private Template validateAndGetTemplate(Long templateId, Long userId) {
-        return templateRepository.findByTemplateIdAndOwner_UserIdAndStatus(templateId, userId, Status.ACTIVE)
+        return templateRepository.findTemplateWithItemsByIdAndOwnerIdAndStatus(templateId, userId, Status.ACTIVE)
                 .orElseThrow(() -> LinkuException.of(ResponseCode.TEMPLATE_NOT_FOUND));
     }
 

--- a/src/main/java/com/linku/backend/global/util/ImageCompressor.java
+++ b/src/main/java/com/linku/backend/global/util/ImageCompressor.java
@@ -3,8 +3,12 @@ package com.linku.backend.global.util;
 import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 public class ImageCompressor {
     private static final int MAX_WIDTH = 800;
@@ -12,11 +16,22 @@ public class ImageCompressor {
     private static final float QUALITY = 0.8f;
 
     public static byte[] resizeAndCompress(MultipartFile file) throws IOException {
+        BufferedImage originalImage = ImageIO.read(file.getInputStream());
+        int originalWidth = originalImage.getWidth();
+        int originalHeight = originalImage.getHeight();
+
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        Thumbnails.of(file.getInputStream())
-                .size(MAX_WIDTH, MAX_HEIGHT)
-                .outputFormat("jpg")
+        Thumbnails.Builder<? extends InputStream> builder =
+                Thumbnails.of(new ByteArrayInputStream(file.getBytes()));
+
+        if (originalWidth > MAX_WIDTH || originalHeight > MAX_HEIGHT) {
+            builder.size(MAX_WIDTH, MAX_HEIGHT);
+        } else {
+            builder.scale(1.0);
+        }
+
+        builder.outputFormat("jpg")
                 .outputQuality(QUALITY)
                 .toOutputStream(outputStream);
 


### PR DESCRIPTION
## 개요
 - Template, Icon 관련 로직 리팩토링
 - ImageCompressor 동작 개선

## 작업사항
- 임베디드 클래스에서 불필요한 @Setter 삭제
- TemplateService의 update/delete 로직을 명시적인 Repository 호출 방식에서 영속성 컨텍스트로의 관리 위임 방식으로 변경
- 템플릿 상세 조회 성능 개선 (Fetch Join 적용, N+1 문제 해결)
- 불필요한 크기 조절 방지, 원본 이미지의 비율을 유지하도록 ImageCompressor 압축 로직 수정